### PR TITLE
Feature/valid error handling

### DIFF
--- a/module-api/src/main/java/com/myfin/api/config/GlobalExceptionHandler.java
+++ b/module-api/src/main/java/com/myfin/api/config/GlobalExceptionHandler.java
@@ -1,13 +1,20 @@
 package com.myfin.api.config;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.myfin.core.AbstractRestApiException;
 import com.myfin.core.exception.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.time.format.DateTimeParseException;
+
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -19,7 +26,24 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        log.error("Occurred MethodArgumentNotValidException.");
         return ResponseEntity.status(ex.getStatusCode())
-                .body(ErrorResponse.errorResponse(ex, request.getRequestURI()));
+                .body(ErrorResponse.errorResponse(ex.getStatusCode(), ex.getBindingResult().getAllErrors().get(0).getDefaultMessage(), request.getRequestURI()));
     }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex, HttpServletRequest request) {
+        if (ex.getCause() instanceof InvalidFormatException ife) {
+            if (ife.getCause() instanceof DateTimeParseException) {
+                log.error("Occurred DateTimeParseException.");
+                return ResponseEntity.status(400)
+                        .body(ErrorResponse.errorResponse(HttpStatus.BAD_REQUEST, "날짜 또는 시간 형식에 맞게 입력해주세요", request.getRequestURI()));
+            }
+        }
+
+        log.error("Occurred HttpMessageNotReadableException.");
+        return ResponseEntity.status(400)
+                .body(ErrorResponse.errorResponse(HttpStatus.BAD_REQUEST, "올바른 형식의 요청값을 입력해주세요", request.getRequestURI()));
+    }
+
 }

--- a/module-api/src/main/java/com/myfin/api/config/GlobalExceptionHandler.java
+++ b/module-api/src/main/java/com/myfin/api/config/GlobalExceptionHandler.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
-public class RestApiExceptionHandler {
+public class GlobalExceptionHandler {
 
     @ExceptionHandler(AbstractRestApiException.class)
     public ResponseEntity<ErrorResponse> handleRestException(AbstractRestApiException ex, HttpServletRequest request) {

--- a/module-api/src/main/java/com/myfin/api/config/GlobalExceptionHandler.java
+++ b/module-api/src/main/java/com/myfin/api/config/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.myfin.core.AbstractRestApiException;
 import com.myfin.core.exception.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -13,6 +14,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AbstractRestApiException.class)
     public ResponseEntity<ErrorResponse> handleRestException(AbstractRestApiException ex, HttpServletRequest request) {
         return ResponseEntity.status(ex.getHttpStatus())
+                .body(ErrorResponse.errorResponse(ex, request.getRequestURI()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        return ResponseEntity.status(ex.getStatusCode())
                 .body(ErrorResponse.errorResponse(ex, request.getRequestURI()));
     }
 }

--- a/module-api/src/main/java/com/myfin/api/config/RestApiExceptionHandler.java
+++ b/module-api/src/main/java/com/myfin/api/config/RestApiExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.myfin.api.controller;
+package com.myfin.api.config;
 
 import com.myfin.core.AbstractRestApiException;
 import com.myfin.core.exception.ErrorResponse;

--- a/module-api/src/main/java/com/myfin/api/dto/Login.java
+++ b/module-api/src/main/java/com/myfin/api/dto/Login.java
@@ -6,9 +6,9 @@ import lombok.*;
 public class Login {
     @Data @NoArgsConstructor @AllArgsConstructor @Builder
     public static class Request {
-        @NotBlank
+        @NotBlank(message = "아이디를 입력해주세요")
         private String userId;
-        @NotBlank
+        @NotBlank(message = "패스워드를 입력해주세요")
         private String password;
     }
 

--- a/module-api/src/main/java/com/myfin/api/dto/SignUp.java
+++ b/module-api/src/main/java/com/myfin/api/dto/SignUp.java
@@ -11,24 +11,24 @@ import java.time.LocalDate;
 public class SignUp {
     @Data @NoArgsConstructor @AllArgsConstructor @Builder
     public static class Request {
-        @NotBlank
+        @NotBlank(message = "아이디를 입력해주세요")
         private String userId;
-        @NotBlank
+        @NotBlank(message = "패스워드를 입력해주세요")
         private String password;
-        @NotBlank
+        @NotBlank(message = "성명을 입력해주세요")
         private String userName;
-        @NotNull
+        @NotNull(message = "생년월일을 입력해주세요")
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         private LocalDate birthDate;
         /** 성별. 남자일 경우 false, 여자일 경우 true */
-        @NotNull
+        @NotNull(message = "성별을 선택해주세요")
         private Boolean sex;
-        @NotBlank
+        @NotBlank(message = "우편번호를 입력해주세요")
         private String zipCode;
-        @NotBlank
+        @NotBlank(message = "도로명주소를 입력해주세요")
         private String address1;
         private String address2;
-        @NotBlank
+        @NotBlank(message = "휴대폰번호를 입력해주세요")
         private String phoneNum;
         private String email;
     }

--- a/module-api/src/main/java/com/myfin/api/dto/SignUp.java
+++ b/module-api/src/main/java/com/myfin/api/dto/SignUp.java
@@ -1,10 +1,10 @@
 package com.myfin.api.dto;
 
 import com.myfin.core.dto.UserDto;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
@@ -12,10 +12,11 @@ import java.time.LocalDate;
 public class SignUp {
     @Data @NoArgsConstructor @AllArgsConstructor @Builder
     public static class Request {
+        @NotNull(message = "아이디를 입력해주세요")
         @NotBlank(message = "아이디를 입력해주세요")
         private String userId;
         @NotBlank(message = "패스워드를 입력해주세요")
-        @Min(value = 8, message = "패스워드는 8자리 이상으로 입력해주세요")
+        @Length(min = 8, message = "패스워드는 8자리 이상으로 입력해주세요")
         private String password;
         @NotBlank(message = "성명을 입력해주세요")
         private String userName;

--- a/module-api/src/main/java/com/myfin/api/dto/SignUp.java
+++ b/module-api/src/main/java/com/myfin/api/dto/SignUp.java
@@ -1,6 +1,7 @@
 package com.myfin.api.dto;
 
 import com.myfin.core.dto.UserDto;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -14,6 +15,7 @@ public class SignUp {
         @NotBlank(message = "아이디를 입력해주세요")
         private String userId;
         @NotBlank(message = "패스워드를 입력해주세요")
+        @Min(value = 8, message = "패스워드는 8자리 이상으로 입력해주세요")
         private String password;
         @NotBlank(message = "성명을 입력해주세요")
         private String userName;

--- a/module-api/src/main/java/com/myfin/api/dto/VerifyIdentity.java
+++ b/module-api/src/main/java/com/myfin/api/dto/VerifyIdentity.java
@@ -9,9 +9,9 @@ import lombok.NoArgsConstructor;
 public class VerifyIdentity {
     @Data @NoArgsConstructor @AllArgsConstructor @Builder
     public static class Request {
-        @NotBlank
+        @NotBlank(message = "휴대폰번호를 입력해주세요")
         private String phoneNum;
-        @NotBlank
+        @NotBlank(message = "인증코드를 입력해주세요")
         private String code;
     }
 

--- a/module-api/src/main/java/com/myfin/api/dto/VerifyRequestIdentity.java
+++ b/module-api/src/main/java/com/myfin/api/dto/VerifyRequestIdentity.java
@@ -15,7 +15,7 @@ public class VerifyRequestIdentity {
     @AllArgsConstructor
     @Builder
     public static class Request {
-        @NotBlank
+        @NotBlank(message = "휴대폰번호를 입력해주세요")
         private String phoneNum;
     }
 

--- a/module-api/src/main/java/com/myfin/api/service/impl/UserSignUpServiceImpl.java
+++ b/module-api/src/main/java/com/myfin/api/service/impl/UserSignUpServiceImpl.java
@@ -108,7 +108,7 @@ public class UserSignUpServiceImpl extends ATopServiceComponent implements UserS
 
     @Override
     @Transactional
-    @CacheEvict(key = "#{request.getUserId()}", value = "checkUserIdResult", cacheManager = "redisCacheManager")
+    @CacheEvict(key = "#request.userId", value = "checkUserIdResult", cacheManager = "redisCacheManager")
     public UserDto signUp(SignUp.Request request) {
         // 요청 검증
         validateSignUpRequest(request);

--- a/module-core/src/main/java/com/myfin/core/exception/ErrorResponse.java
+++ b/module-core/src/main/java/com/myfin/core/exception/ErrorResponse.java
@@ -3,6 +3,7 @@ package com.myfin.core.exception;
 import com.myfin.core.AbstractRestApiException;
 import com.myfin.core.util.SeoulDateTime;
 import lombok.*;
+import org.springframework.http.HttpStatusCode;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -20,6 +21,15 @@ public class ErrorResponse {
                 .timestamp(SeoulDateTime.now().toString())
                 .httpStatus(ex.getHttpStatus())
                 .errorMessage(ex.getErrorMessage())
+                .path(path)
+                .build();
+    }
+
+    public static ErrorResponse errorResponse(HttpStatusCode statusCode, String message, String path) {
+        return ErrorResponse.builder()
+                .timestamp(SeoulDateTime.now().toString())
+                .httpStatus(statusCode.value())
+                .errorMessage(message)
                 .path(path)
                 .build();
     }


### PR DESCRIPTION
## 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
### AS-IS
- Request 데이터의 `@Valid` 검증에 의한 에러가 핸들링되지 않아서 `DefaultHandlingExceptionResolver`에 의해서 에러메시지가 반환되었음.
- 아이디 중복확인 캐싱 이후 회원가입 성공 시 해당 아이디를 중복확인 캐싱에서 삭제하는 로직에서 에러가 발생
```java
@CacheEvict(key = "#{request.getUserId()}", value = "checkUserIdResult", cacheManager = "redisCacheManager")
```

### TO-BE
- Request 데이터의 `@Valid` 어노테이션에 대해 각각 `message`를 정의
```java
        @NotNull(message = "아이디를 입력해주세요")
        @NotBlank(message = "아이디를 입력해주세요")
        private String userId;
```
- `GlobalExceptionHandler`에 `@Valid` 에러 발생 예외 클래스를 핸들링 처리
```java
@ExceptionHandler(MethodArgumentNotValidException.class)
    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex, HttpServletRequest request) {
        log.error("Occurred MethodArgumentNotValidException.");
        return ResponseEntity.status(ex.getStatusCode())
                .body(ErrorResponse.errorResponse(ex.getStatusCode(), ex.getBindingResult().getAllErrors().get(0).getDefaultMessage(), request.getRequestURI()));
    }

    @ExceptionHandler(HttpMessageNotReadableException.class)
    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex, HttpServletRequest request) {
        if (ex.getCause() instanceof InvalidFormatException ife) {
            if (ife.getCause() instanceof DateTimeParseException) {
                log.error("Occurred DateTimeParseException.");
                return ResponseEntity.status(400)
                        .body(ErrorResponse.errorResponse(HttpStatus.BAD_REQUEST, "날짜 또는 시간 형식에 맞게 입력해주세요", request.getRequestURI()));
            }
        }
        log.error("Occurred HttpMessageNotReadableException.");
        return ResponseEntity.status(400)
                .body(ErrorResponse.errorResponse(HttpStatus.BAD_REQUEST, "올바른 형식의 요청값을 입력해주세요", request.getRequestURI()));
    }
```
- 아이디 중복확인 캐싱 처리 이후 회원가입 시 해당 아이디의 중복확인 결과를 재갱신하기 위해 `@CacheEvict`을 선언하였는데, `key` 값이 올바르지 않아서 오류가 발생.
```java
@CacheEvict(key = "#request.userId", value = "checkUserIdResult", cacheManager = "redisCacheManager")
```

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

***
<!-- 관련 이슈 링크 -->
CLOSE `none`