### PR TITLE
Add feature for users to retrieve their account info 

### DIFF
--- a/module-api/src/main/java/com/myfin/api/controller/AccountController.java
+++ b/module-api/src/main/java/com/myfin/api/controller/AccountController.java
@@ -35,7 +35,9 @@ public class AccountController {
     @GetMapping("/accounts")
     @ResponseStatus(HttpStatus.OK)
     public FindMyAccount.Response findMyAccount(@RequestBody @Valid FindMyAccount.Request request) {
-        return FindMyAccount.Response.fromDto();
+        return FindMyAccount.Response.fromDto(
+                accountService.findMyAccount(request)
+        );
     }
 
 }

--- a/module-api/src/main/java/com/myfin/api/controller/AccountController.java
+++ b/module-api/src/main/java/com/myfin/api/controller/AccountController.java
@@ -2,6 +2,7 @@ package com.myfin.api.controller;
 
 import com.myfin.api.dto.CreateAccount;
 import com.myfin.api.dto.DeleteAccount;
+import com.myfin.api.dto.FindMyAccount;
 import com.myfin.api.service.AccountService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,12 @@ public class AccountController {
         return DeleteAccount.Response.fromDto(
                 accountService.deleteAccount(request)
         );
+    }
+
+    @GetMapping("/accounts")
+    @ResponseStatus(HttpStatus.OK)
+    public FindMyAccount.Response findMyAccount(@RequestBody @Valid FindMyAccount.Request request) {
+        return FindMyAccount.Response.fromDto();
     }
 
 }

--- a/module-api/src/main/java/com/myfin/api/dto/FindMyAccount.java
+++ b/module-api/src/main/java/com/myfin/api/dto/FindMyAccount.java
@@ -1,0 +1,44 @@
+package com.myfin.api.dto;
+
+import com.myfin.core.dto.AccountDto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+public class FindMyAccount {
+    @Data @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class Request {
+        @NotNull(message = "계좌번호를 입력해주세요")
+        @NotBlank(message = "계좌번호를 입력해주세요")
+        private String accountNumber;
+        @NotNull(message = "계좌비밀번호를 입력해주세요")
+        @NotBlank(message = "계좌비밀번호를 입력해주세요")
+        private String accountPassword;
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @Data @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class Response extends TopResponse {
+        private AccountResponse account;
+        public static Response fromDto(AccountDto dto) {
+            return Response.builder()
+                    .account(AccountResponse.fromDto(dto))
+                    .build();
+        }
+        @Data @NoArgsConstructor @AllArgsConstructor @Builder
+        private static class AccountResponse {
+            private String number;
+            private long balance;
+            private String createdAt;
+            private String updatedAt;
+            private static AccountResponse fromDto(AccountDto dto) {
+                return AccountResponse.builder()
+                        .number(dto.getNumber())
+                        .balance(dto.getBalance())
+                        .createdAt(getDateTimeIfPresent(dto.getCreatedAt()))
+                        .updatedAt(getDateTimeIfPresent(dto.getUpdatedAt()))
+                        .build();
+            }
+        }
+    }
+}

--- a/module-api/src/main/java/com/myfin/api/service/AccountService.java
+++ b/module-api/src/main/java/com/myfin/api/service/AccountService.java
@@ -2,6 +2,7 @@ package com.myfin.api.service;
 
 import com.myfin.api.dto.CreateAccount;
 import com.myfin.api.dto.DeleteAccount;
+import com.myfin.api.dto.FindMyAccount;
 import com.myfin.core.dto.AccountDto;
 
 public interface AccountService {
@@ -19,4 +20,11 @@ public interface AccountService {
      * @return 계좌 DTO 클래스
      */
     AccountDto deleteAccount(DeleteAccount.Request request);
+
+    /**
+     * 내 계좌 조회.
+     * @param request 계좌 조회 요청 DTO 클래스
+     * @return 계좌 DTO 클래스
+     */
+    AccountDto findMyAccount(FindMyAccount.Request request);
 }

--- a/module-api/src/test/java/com/myfin/api/mock/MockFactory.java
+++ b/module-api/src/test/java/com/myfin/api/mock/MockFactory.java
@@ -53,8 +53,7 @@ public class MockFactory {
                 .build();
     }
 
-    public static Account mock_account_for_db(User owner,
-                                       Long balance) {
+    public static Account mock_account_for_db(User owner, Long balance) {
         return Account.builder()
                 .number("account_number")
                 .password("1234")
@@ -62,6 +61,11 @@ public class MockFactory {
                 .build()
                 .associate(owner);
     }
+
+    public static Account mock_account(User owner, Long balance) {
+        return mock_account(owner, balance, null, null, null);
+    }
+
     public static Account mock_account(User owner,
                                        Long balance,
                                        LocalDateTime createdAt,


### PR DESCRIPTION
## 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->

로그인 유저의 계좌 정보를 조회하는 API를 추가하였다.
계좌 정보를 조회하기 위해 유저는 `계좌번호와 계좌비밀번호`를 입력/요청하게 되고, 유저 정보는 토큰 Payload에 담긴 유저 ID로 대체한다.
계좌 정보는 민감한 개인정보와 데이터 수정이 잦은 잔액을 고려하여 캐싱 처리는 하지 않는 것으로 한다.

### AS-IS
- 유저의 계좌 정보 조회 API가 없었다. 

### TO-BE
- 유저의 계좌 정보 조회 API를 추가하였다 <- [API 명세서 참고](https://github.com/hseungho/zb-myfin/blob/main/docs/API_Specification.md)

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

***
<!-- 관련 이슈 링크 -->
CLOSE #19 