### PR TITLE
Add account search to improve query performance

### DIFF
--- a/module-api/src/main/java/com/myfin/api/controller/SearchController.java
+++ b/module-api/src/main/java/com/myfin/api/controller/SearchController.java
@@ -1,0 +1,19 @@
+package com.myfin.api.controller;
+
+import com.myfin.api.dto.SearchAccount;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class SearchController {
+
+    @GetMapping("/search/accounts")
+    @ResponseStatus(HttpStatus.OK)
+    public SearchAccount.Response searchAccount(@RequestParam("param") final String param) {
+        return SearchAccount.Response.fromDto();
+    }
+
+}

--- a/module-api/src/main/java/com/myfin/api/controller/SearchController.java
+++ b/module-api/src/main/java/com/myfin/api/controller/SearchController.java
@@ -1,6 +1,7 @@
 package com.myfin.api.controller;
 
 import com.myfin.api.dto.SearchAccount;
+import com.myfin.api.service.AccountUserSearchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -10,10 +11,14 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class SearchController {
 
+    private final AccountUserSearchService accountUserSearchService;
+
     @GetMapping("/search/accounts")
     @ResponseStatus(HttpStatus.OK)
-    public SearchAccount.Response searchAccount(@RequestParam("param") final String param) {
-        return SearchAccount.Response.fromDto();
+    public SearchAccount.Response searchAccount(@RequestParam(value = "keyword", required = true) final String keyword) {
+        return SearchAccount.Response.fromDto(
+                accountUserSearchService.search(keyword)
+        );
     }
 
 }

--- a/module-api/src/main/java/com/myfin/api/controller/SearchController.java
+++ b/module-api/src/main/java/com/myfin/api/controller/SearchController.java
@@ -15,7 +15,7 @@ public class SearchController {
 
     @GetMapping("/search/accounts")
     @ResponseStatus(HttpStatus.OK)
-    public SearchAccount.Response searchAccount(@RequestParam(value = "keyword", required = true) final String keyword) {
+    public SearchAccount.Response searchAccount(@RequestParam(value = "param", required = true) final String keyword) {
         return SearchAccount.Response.fromDto(
                 accountUserSearchService.search(keyword)
         );

--- a/module-api/src/main/java/com/myfin/api/dto/SearchAccount.java
+++ b/module-api/src/main/java/com/myfin/api/dto/SearchAccount.java
@@ -1,0 +1,36 @@
+package com.myfin.api.dto;
+
+import com.myfin.core.dto.AccountDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class SearchAccount {
+    @Data @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class Response {
+        private MetaResponse meta;
+        private DocumentResponse document;
+
+        public static Response fromDto(AccountDto dto) {
+            return dto != null ?
+                    Response.builder()
+                            .meta(new MetaResponse(true))
+                            .document(new DocumentResponse(dto.getOwner().getName()))
+                            .build() :
+                    Response.builder()
+                            .meta(new MetaResponse(false))
+                            .build();
+        }
+
+        @Data @NoArgsConstructor @AllArgsConstructor @Builder
+        private static class MetaResponse {
+            private boolean result;
+        }
+
+        @Data @NoArgsConstructor @AllArgsConstructor @Builder
+        private static class DocumentResponse {
+            private String userName;
+        }
+    }
+}

--- a/module-api/src/main/java/com/myfin/api/dto/SearchAccount.java
+++ b/module-api/src/main/java/com/myfin/api/dto/SearchAccount.java
@@ -1,6 +1,6 @@
 package com.myfin.api.dto;
 
-import com.myfin.core.dto.AccountDto;
+import com.myfin.core.dto.UserDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,11 +12,11 @@ public class SearchAccount {
         private MetaResponse meta;
         private DocumentResponse document;
 
-        public static Response fromDto(AccountDto dto) {
+        public static Response fromDto(UserDto dto) {
             return dto != null ?
                     Response.builder()
                             .meta(new MetaResponse(true))
-                            .document(new DocumentResponse(dto.getOwner().getName()))
+                            .document(new DocumentResponse(dto.getName()))
                             .build() :
                     Response.builder()
                             .meta(new MetaResponse(false))

--- a/module-api/src/main/java/com/myfin/api/service/AccountUserSearchService.java
+++ b/module-api/src/main/java/com/myfin/api/service/AccountUserSearchService.java
@@ -1,0 +1,15 @@
+package com.myfin.api.service;
+
+import com.myfin.core.dto.UserDto;
+import jakarta.annotation.Nullable;
+
+public interface AccountUserSearchService {
+
+    /**
+     * 계좌번호 또는 휴대폰 번호를 이용하여 계좌 검색.
+     * @param keyword 계좌번호 또는 휴대폰번호
+     * @return 계좌 DTO 클래스. 만일 리턴값이 null이라면 조회되지 않았음을 의미
+     */
+    @Nullable
+    UserDto search(String keyword);
+}

--- a/module-api/src/main/java/com/myfin/api/service/impl/AccountUserSearchServiceImpl.java
+++ b/module-api/src/main/java/com/myfin/api/service/impl/AccountUserSearchServiceImpl.java
@@ -24,20 +24,20 @@ public class AccountUserSearchServiceImpl extends TopServiceComponent implements
     @Override
     @Transactional(readOnly = true)
     public UserDto search(String keyword) {
-        User user;
+        User searchedUser;
 
         if (isPhoneNumber(keyword)) {
-            user = userRepository.findByPhoneNum(keyword)
+            searchedUser = userRepository.findByPhoneNum(keyword)
                     .orElse(null);
-            if (user == null || user.getAccount() == null) return null;
+            if (searchedUser == null || searchedUser.getAccount() == null) return null;
         } else {
             Account account = accountRepository.findByNumber(keyword)
                     .orElse(null);
             if (account == null) return null;
-            user = account.getOwner();
+            searchedUser = account.getOwner();
         }
 
-        return UserDto.fromEntity(user);
+        return UserDto.fromEntity(searchedUser);
     }
 
     private boolean isPhoneNumber(String keyword) {
@@ -45,6 +45,13 @@ public class AccountUserSearchServiceImpl extends TopServiceComponent implements
             // 키워드를 입력하지 않은 경우
             throw new BadRequestException("검색할 키워드를 입력해주세요");
         }
-        return keyword.startsWith("010");
+        if (keyword.startsWith("010")) {
+            if (isInvalidPhoneNumPattern(keyword)) {
+                // 휴대폰번호가 올바른 패턴이 아닌 경우
+                throw new BadRequestException("올바른 휴대폰번호로 입력해주세요");
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/module-api/src/main/java/com/myfin/api/service/impl/AccountUserSearchServiceImpl.java
+++ b/module-api/src/main/java/com/myfin/api/service/impl/AccountUserSearchServiceImpl.java
@@ -1,0 +1,50 @@
+package com.myfin.api.service.impl;
+
+import com.myfin.api.service.AccountUserSearchService;
+import com.myfin.api.service.TopServiceComponent;
+import com.myfin.core.dto.UserDto;
+import com.myfin.core.entity.Account;
+import com.myfin.core.entity.User;
+import com.myfin.core.exception.impl.BadRequestException;
+import com.myfin.core.repository.AccountRepository;
+import com.myfin.core.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AccountUserSearchServiceImpl extends TopServiceComponent implements AccountUserSearchService {
+
+    private final UserRepository userRepository;
+    private final AccountRepository accountRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDto search(String keyword) {
+        User user;
+
+        if (isPhoneNumber(keyword)) {
+            user = userRepository.findByPhoneNum(keyword)
+                    .orElse(null);
+            if (user == null || user.getAccount() == null) return null;
+        } else {
+            Account account = accountRepository.findByNumber(keyword)
+                    .orElse(null);
+            if (account == null) return null;
+            user = account.getOwner();
+        }
+
+        return UserDto.fromEntity(user);
+    }
+
+    private boolean isPhoneNumber(String keyword) {
+        if (hasNotTexts(keyword)) {
+            // 키워드를 입력하지 않은 경우
+            throw new BadRequestException("검색할 키워드를 입력해주세요");
+        }
+        return keyword.startsWith("010");
+    }
+}

--- a/module-api/src/test/java/com/myfin/api/service/impl/AccountUserSearchServiceImplUnitTest.java
+++ b/module-api/src/test/java/com/myfin/api/service/impl/AccountUserSearchServiceImplUnitTest.java
@@ -1,7 +1,125 @@
 package com.myfin.api.service.impl;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.myfin.api.mock.MockFactory;
+import com.myfin.core.dto.UserDto;
+import com.myfin.core.entity.Account;
+import com.myfin.core.entity.User;
+import com.myfin.core.exception.impl.BadRequestException;
+import com.myfin.core.repository.AccountRepository;
+import com.myfin.core.repository.UserRepository;
+import com.myfin.core.type.UserType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
 class AccountUserSearchServiceImplUnitTest {
 
+    @InjectMocks private AccountUserSearchServiceImpl service;
+
+    @Mock private UserRepository userRepository;
+
+    @Mock private AccountRepository accountRepository;
+
+    @Test
+    @DisplayName("계좌 검색 - 성공 - 계좌번호 검색")
+    void test_search_success_when_keywordIsAccountNumber() {
+        // given
+        User owner = MockFactory.mock_user(UserType.ROLE_USER);
+        Account account = MockFactory.mock_account(owner, 10000L);
+        given(accountRepository.findByNumber(anyString()))
+                .willReturn(Optional.of(account));
+        // when
+        UserDto result = service.search("123412341234");
+        // then
+        assertEquals(owner.getName(), result.getName());
+    }
+
+    @Test
+    @DisplayName("계좌 검색 - 성공 - 휴대폰번호 검색")
+    void test_search_success_when_keywordIsPhoneNum() {
+        // given
+        User owner = MockFactory.mock_user(UserType.ROLE_USER);
+        MockFactory.mock_account(owner, 10000L);
+        given(userRepository.findByPhoneNum(anyString()))
+                .willReturn(Optional.of(owner));
+        // when
+        UserDto result = service.search("01012341234");
+        // then
+        assertEquals(owner.getName(), result.getName());
+    }
+
+    @Test
+    @DisplayName("계좌 검색 - 성공 - 계좌번호에 해당하는 계좌 없음")
+    void test_search_success_when_keyIsAccNum_noResultAccount() {
+        // given
+        given(accountRepository.findByNumber(anyString()))
+                .willReturn(Optional.empty());
+        // when
+        UserDto result = service.search("123412341234");
+        // then
+        assertNull(result);
+    }
+
+    @Test
+    @DisplayName("계좌 검색 - 성공 - 휴대폰번호에 해당하는 유저는 존재하지만 유저의 계좌가 없는 경우")
+    void test_search_success_when_keyIsPhone_noResultAccount() {
+        // given
+        User owner = MockFactory.mock_user(UserType.ROLE_USER);
+        given(userRepository.findByPhoneNum(anyString()))
+                .willReturn(Optional.of(owner));
+        // when
+        UserDto result = service.search("01012341234");
+        // then
+        assertNull(result);
+    }
+
+    @Test
+    @DisplayName("계좌 검색 - 성공 - 휴대폰번호에 해당하는 유저가 존재하지 않은 경우")
+    void test_search_success_when_keyIsPhone_noResultUser() {
+        // given
+        given(userRepository.findByPhoneNum(anyString()))
+                .willReturn(Optional.empty());
+        // when
+        UserDto result = service.search("01012341234");
+        // then
+        assertNull(result);
+    }
+
+    @Test
+    @DisplayName("계좌 검색 - 실패 - 키워드 미제공")
+    void test_search_failed_when_hasNotKeyword() {
+        // given
+        // when
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> service.search(null)
+        );
+        // then
+        assertEquals(400, ex.getHttpStatus());
+        assertEquals("검색할 키워드를 입력해주세요", ex.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("계좌 검색 - 실패 - 유효하지 않은 휴대폰번호 패턴")
+    void test_search_failed_when_invalidPhonePattern() {
+        // given
+        // when
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> service.search("010123412345")
+        );
+        // then
+        assertEquals(400, ex.getHttpStatus());
+        assertEquals("올바른 휴대폰번호로 입력해주세요", ex.getErrorMessage());
+    }
 }

--- a/module-api/src/test/java/com/myfin/api/service/impl/AccountUserSearchServiceImplUnitTest.java
+++ b/module-api/src/test/java/com/myfin/api/service/impl/AccountUserSearchServiceImplUnitTest.java
@@ -1,0 +1,7 @@
+package com.myfin.api.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AccountUserSearchServiceImplUnitTest {
+
+}

--- a/module-core/src/main/java/com/myfin/core/entity/Account.java
+++ b/module-core/src/main/java/com/myfin/core/entity/Account.java
@@ -12,6 +12,10 @@ import lombok.experimental.SuperBuilder;
 import java.time.LocalDateTime;
 
 @Entity(name = "account")
+@Table(
+        name = "account",
+        indexes = @Index(name = "idx__act_no", columnList = "act_no")
+)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/module-core/src/main/java/com/myfin/core/entity/User.java
+++ b/module-core/src/main/java/com/myfin/core/entity/User.java
@@ -21,6 +21,10 @@ import java.util.Collection;
 import java.util.List;
 
 @Entity(name = "users")
+@Table(
+        name = "users",
+        indexes = @Index(name = "idx__phone_num", columnList = "phone_num")
+)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/module-core/src/main/java/com/myfin/core/repository/AccountRepository.java
+++ b/module-core/src/main/java/com/myfin/core/repository/AccountRepository.java
@@ -5,6 +5,8 @@ import com.myfin.core.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
@@ -12,4 +14,5 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
 
     boolean existsByNumber(String number);
 
+    Optional<Account> findByNumber(String number);
 }

--- a/module-core/src/main/java/com/myfin/core/repository/UserRepository.java
+++ b/module-core/src/main/java/com/myfin/core/repository/UserRepository.java
@@ -15,4 +15,6 @@ public interface UserRepository extends JpaRepository<User, String> {
 
     Optional<User> findByUserId(String userId);
 
+    Optional<User> findByPhoneNum(String phoneNum);
+
 }


### PR DESCRIPTION
## 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->

계좌 검색 API를 추가 구현하였다. 계좌 검색 또한 로그인된 유저에 한해서만 가능하다.
계좌 검색은 계좌번호 또는 휴대폰번호로 조회가능하다.  계좌 검색 기능의 응답으로는 검색결과 여부와, 검색이 성공했다면 해당 계좌의 유저 성명을 반환한다.

검색 API 시 데이터가 많아질 경우 풀스캔에 대한 성능 저하를 어느 정도 커버하기 위해 Account와 User 테이블의 특정 컬럼에 인덱싱을 설정하였다.
Account는 계좌번호를 인덱싱 설정하였고, User는 휴대폰번호를 인덱싱 설정하였다.

TODO: 더미 데이터 100만개 이상이 있을 경우의 쿼리 플랜을 확인하여 성능 개선이 되었는지 확인해야 한다.

### AS-IS
- 계좌 검색 API가 없었다.
- 검색에 사용되는 컬럼의 인덱싱이 처리되지 않았다.

### TO-BE
- 계좌 검색 API를 추가 구현하였다. <- [API 명세서 참고](https://github.com/hseungho/zb-myfin/blob/main/docs/API_Specification.md)
- 검색에 사용되는 컬럼의 인덱싱을 설정하였다. `User.phoneNum, Account.number`

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

***
<!-- 관련 이슈 링크 -->
CLOSE #17 