### PR TITLE
Fix the account number generator

### DIFF
--- a/module-core/src/main/java/com/myfin/core/util/Generator.java
+++ b/module-core/src/main/java/com/myfin/core/util/Generator.java
@@ -12,8 +12,11 @@ public class Generator {
 
     public static String generateAccountNumber() {
         Random random = new Random();
-        StringBuffer sb = new StringBuffer();
-        for (int i = 0; i < 14; i++) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 3; i++) {
+            sb.append(random.nextInt(7) + 2);
+        }
+        for (int i = 0; i < 11; i++) {
             sb.append(random.nextInt(10));
         }
         return sb.toString();

--- a/module-core/src/test/java/com/myfin/core/util/GeneratorTest.java
+++ b/module-core/src/test/java/com/myfin/core/util/GeneratorTest.java
@@ -1,0 +1,23 @@
+package com.myfin.core.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GeneratorTest {
+
+    @Test
+    @DisplayName("계좌번호 생성기 테스트 - 1000만번동안 계좌번호에 010이 안포함되는지 확인")
+    void test_generateAccountNumber() {
+        // given
+        // when
+        // then
+        for (int i = 0; i < 10_000_000; i++) {
+            String accountNumber = Generator.generateAccountNumber();
+            assertEquals(14, accountNumber.length());
+            assertFalse(accountNumber.startsWith("010"));
+        }
+    }
+
+}


### PR DESCRIPTION
## 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
Resolve #22 

계좌번호 생성 시 앞 3자리가 010이 되지 않도록 하는 로직으로 수정.
계좌번호와 휴대폰번호에 대한 분기를 앞자리 010을 기준으로 하기 때문에, 계좌번호의 앞 3자리는 010이 되어선 안된다는 기획에 의해 수정 

### AS-IS
```java
    public static String generateAccountNumber() {
        Random random = new Random();
        StringBuffer sb = new StringBuffer();
        for (int i = 0; i < 14; i++) {
            sb.append(random.nextInt(10));
        }
        return sb.toString();
```

### TO-BE
```java
    public static String generateAccountNumber() {
        Random random = new Random();
        StringBuilder sb = new StringBuilder();
        for (int i = 0; i < 3; i++) {
            sb.append(random.nextInt(7) + 2);
        }
        for (int i = 0; i < 11; i++) {
            sb.append(random.nextInt(10));
        }
        return sb.toString();
```

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
```java
    @Test
    @DisplayName("계좌번호 생성기 테스트 - 1000만번동안 계좌번호에 010이 안포함되는지 확인")
    void test_generateAccountNumber() {
        // given
        // when
        // then
        for (int i = 0; i < 10_000_000; i++) {
            String accountNumber = Generator.generateAccountNumber();
            assertEquals(14, accountNumber.length());
            assertFalse(accountNumber.startsWith("010"));
        }
    }
```
- [ ] API 테스트 
