### PR TITLE
Fix account deletion logic

### DIFF
--- a/module-api/src/main/java/com/myfin/api/dto/DeleteAccount.java
+++ b/module-api/src/main/java/com/myfin/api/dto/DeleteAccount.java
@@ -31,7 +31,11 @@ public class DeleteAccount {
 
         public static Response fromDto(AccountDto dto) {
             return Response.builder()
-                    .accountNumber(dto.getNumber())
+                    .accountNumber(
+                            dto.getNumber().startsWith("DEL_") ?
+                                    dto.getNumber().replace("DEL_", "") :
+                                    dto.getNumber()
+                    )
                     .createdAt(DateUtil.getDateTimeIfPresent(dto.getCreatedAt()))
                     .deletedAt(DateUtil.getDateTimeIfPresent(dto.getDeletedAt()))
                     .build();

--- a/module-api/src/main/java/com/myfin/api/service/impl/AccountServiceImpl.java
+++ b/module-api/src/main/java/com/myfin/api/service/impl/AccountServiceImpl.java
@@ -60,7 +60,7 @@ public class AccountServiceImpl implements AccountService {
 
         validateDeleteAccountRequest(request, account);
 
-        account.delete();
+        account.delete(passwordEncoderService.encode("0000"));
 
         return AccountDto.fromEntity(account);
     }

--- a/module-api/src/test/java/com/myfin/api/service/impl/AccountServiceImplUnitTest.java
+++ b/module-api/src/test/java/com/myfin/api/service/impl/AccountServiceImplUnitTest.java
@@ -197,9 +197,10 @@ class AccountServiceImplUnitTest {
                 .accountPassword("1234").build());
         // then
         assertNotNull(result);
-        Assertions.assertEquals("account_number", result.getNumber());
-        Assertions.assertEquals(now, result.getCreatedAt());
+        assertEquals("DEL_account_number", result.getNumber());
+        assertEquals(now, result.getCreatedAt());
         assertNotNull(result.getDeletedAt());
+        assertNull(result.getOwner());
     }
 
     @Test

--- a/module-core/src/main/java/com/myfin/core/dto/AccountDto.java
+++ b/module-core/src/main/java/com/myfin/core/dto/AccountDto.java
@@ -27,7 +27,7 @@ public class AccountDto {
                 .createdAt(entity.getCreatedAt())
                 .updatedAt(entity.getUpdatedAt())
                 .deletedAt(entity.getDeletedAt())
-                .owner(UserDto.fromEntity(entity.getOwner()))
+                .owner(entity.getOwner() != null ? UserDto.fromEntity(entity.getOwner()) : null)
                 .build();
     }
 

--- a/module-core/src/main/java/com/myfin/core/entity/Account.java
+++ b/module-core/src/main/java/com/myfin/core/entity/Account.java
@@ -68,8 +68,11 @@ public class Account extends BaseEntity {
         return this.deletedAt != null;
     }
 
-    public void delete() {
+    public void delete(final String deletedPassword) {
+        this.number = "DEL_" + this.number;
+        this.password = deletedPassword;
         this.deletedAt = SeoulDateTime.now();
+        this.owner = null;
     }
 
     public void deposit(Long amount) {

--- a/module-core/src/main/java/com/myfin/core/repository/AccountRepository.java
+++ b/module-core/src/main/java/com/myfin/core/repository/AccountRepository.java
@@ -3,6 +3,7 @@ package com.myfin.core.repository;
 import com.myfin.core.entity.Account;
 import com.myfin.core.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -14,5 +15,6 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
 
     boolean existsByNumber(String number);
 
+    @Query(value = "SELECT a FROM account a WHERE a.deletedAt = null ")
     Optional<Account> findByNumber(String number);
 }


### PR DESCRIPTION
## 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->

Resolve #20 

AS-IS:
계좌 삭제 시 deletedAt만 추가하고 있다

TO-BE:
계좌 삭제 시
계좌번호 앞에 DEL_ prefix를 추가하여 수정한다.
계좌비밀번호를 0000으로 수정한다.
소유자와의 관계를 끊는다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

***